### PR TITLE
_exporter_expand_tag is called for negated tags too, so use _exporter_expand_sub instead

### DIFF
--- a/lib/MoobX.pm
+++ b/lib/MoobX.pm
@@ -20,26 +20,33 @@ use experimental 'signatures';
 use parent 'Exporter::Tiny';
 
 our @EXPORT = qw/ observer observable autorun :attributes :traits /;
+our %EXPORT_TAGS = (
+    'attributes' => [ '__ATTRIBUTES__' ],
+    'traits'     => [ '__TRAITS__' ],
+);
 
 our $WARN_NO_DEPS = 1;
 
-sub _exporter_expand_tag {
-    my( $class, $name, $args, $globals ) = @_;
+sub _exporter_expand_sub {
+    my ( $class, $name, $args, $globals ) = ( shift, @_ );
 
-    if ( $name eq 'attributes' ) {
+    if ( $name eq '__ATTRIBUTES__' ) {
         my $target = $globals->{into};
-
+        return if ref $target;
+        local $@;
         eval qq{
             package $target;
             use parent 'MoobX::Attributes';
             1;
         } or die $@;
+        return;
     }
-    elsif( $name eq 'traits' ) {
-        use_module( 'MoobX::Trait::'.$_) for qw/ Observer Observable /;
+    elsif ( $name eq '__TRAITS__' ) {
+        use_module( "MoobX::Trait::$_" ) for qw/ Observer Observable /;
+        return;
     }
 
-    return ();
+    return $class->SUPER::_exporter_expand_sub( $name, $args, $globals );
 }
 
 our $graph = Graph::Directed->new;


### PR DESCRIPTION
Fixes #7.

This uses the `_exporter_expand_sub` method instead of `_exporter_expand_tag` to implement `:attributes` and `:traits`. This is because `_exporter_expand_sub` is not called for negated exports, while `_exporter_expand_tag` can be.

Also adds an `%EXPORT_TAGS` variable to provide the plumbing so that `:attributes` becomes `__ATTRIBUTES__`, etc.